### PR TITLE
Install PSScriptAnalyzer only if it is not there yet

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,13 @@ runs:
         if ($null -eq $analyzerModule) {
           Install-Module -Name PSScriptAnalyzer -Force
         }
-        Install-Module -Name ConvertToSARIF -Force
+
+        $sarifModule = Get-Module -ListAvailable -Name ConvertToSARIF
+        if ($null -eq $sarifModule) {
+          Install-Module -Name ConvertToSARIF -Force
+        }
         Import-Module -Name ConvertToSARIF -Force
+
         $htPSA = [ordered]@{ Path = '${{ inputs.path }}'; }
         Write-Output "Modules installed, now running tests."
         if(![string]::IsNullOrEmpty('${{ inputs.customRulePath }}')) { $htPSA.add('CustomRulePath', @(${{ inputs.customRulePath }})) }

--- a/action.yml
+++ b/action.yml
@@ -55,11 +55,14 @@ runs:
     - name: Run PSScriptAnalyzer and ConvertToSARIF
       shell: pwsh
       run: |
-        Install-Module -Name PSScriptAnalyzer -Force
+        $analyzerModule = Get-Module -ListAvailable -Name PSScriptAnalyzer
+        if ($null -eq $analyzerModule) {
+          Install-Module -Name PSScriptAnalyzer -Force
+        }
         Install-Module -Name ConvertToSARIF -Force
         Import-Module -Name ConvertToSARIF -Force
         $htPSA = [ordered]@{ Path = '${{ inputs.path }}'; }
-        Write-Host test
+        Write-Output "Modules installed, now running tests."
         if(![string]::IsNullOrEmpty('${{ inputs.customRulePath }}')) { $htPSA.add('CustomRulePath', @(${{ inputs.customRulePath }})) }
         if(![string]::IsNullOrEmpty('${{ inputs.recurseCustomRulePath }}')) { $htPSA.add('RecurseCustomRulePath', $true) }
         if(![string]::IsNullOrEmpty('${{ inputs.excludeRule }}')) { $htPSA.add('ExcludeRule', @(${{ inputs.excludeRule }})) }


### PR DESCRIPTION
This avoids an error message when PSScriptAnalyzer is already there (the default in current GitHub Actions using ubuntu-latest).

Also changed the test message to a more production-compatible one.